### PR TITLE
Add tool with support for all Stryker args

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -3,11 +3,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerStrykerRun } from "./tools/strykerRun.js";
 import { registerStrykerReadJson } from "./tools/strykerReadJson.js";
 import { registerStrykerMutate } from "./tools/strykerMutate.js";
+import { registerStrykerRunWithArgs } from "./tools/strykerRunWithArgs.js";
 
 const server = new McpServer({ name: "stryker-mcp", version: "0.1.0" });
 
 // Register tools
 registerStrykerRun(server);
+registerStrykerRunWithArgs(server);
 registerStrykerReadJson(server);
 registerStrykerMutate(server);
 

--- a/packages/mcp-server/src/schemas/strykerRunInput.ts
+++ b/packages/mcp-server/src/schemas/strykerRunInput.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+/**
+ * Zod schema for the strykerRun tool.
+ * Includes all common CLI-exposed options and a configOverrides object for rich settings.
+ */
+export const ZStrykerRunInputShape: z.ZodRawShape = {
+  // Required
+  cwd: z.string().describe("Project directory containing tests"),
+
+  // Common / CLI-mapped
+  mutate: z.array(z.string()).optional().describe("Glob(s) of files to mutate (comma-joined for CLI)"),
+  files: z.array(z.string()).optional().describe("Alias for mutate"),
+  ignorePatterns: z.array(z.string()).optional().describe("Glob(s) to exclude from sandbox copy"),
+  reporters: z.array(z.string()).optional().describe("Reporter names, e.g. ['progress','json']"),
+  logLevel: z.enum(["off","fatal","error","warn","info","debug","trace"]).optional(),
+  fileLogLevel: z.enum(["off","fatal","error","warn","info","debug","trace"]).optional(),
+  concurrency: z.number().int().positive().optional(),
+  buildCommand: z.string().optional().describe("Command to run before tests (e.g. 'npm run build')"),
+  coverageAnalysis: z.enum(["off", "all", "perTest"]).optional(),
+  testRunner: z.string().optional().describe("jest | mocha | jasmine | karma | vitest | tap | cucumber | command"),
+  testRunnerNodeArgs: z.array(z.string()).optional().describe("Node exec args for test runner child process"),
+  checkers: z.array(z.string()).optional().describe("Checker plugins e.g. ['typescript']"),
+  checkerNodeArgs: z.array(z.string()).optional().describe("Node exec args for checker child process"),
+  packageManager: z.enum(["npm","yarn","pnpm"]).optional(),
+  tsconfigFile: z.string().optional(),
+  tempDirName: z.string().optional(),
+  maxTestRunnerReuse: z.number().int().min(0).optional(),
+
+  // Booleans / toggles
+  allowConsoleColors: z.boolean().optional(),
+  allowEmpty: z.boolean().optional(),
+  disableBail: z.boolean().optional(),
+  dryRunOnly: z.boolean().optional(),
+  force: z.boolean().optional(),
+  ignoreStatic: z.boolean().optional(),
+  incremental: z.boolean().optional(),
+  inPlace: z.boolean().optional(),
+  cleanTempDir: z.union([z.boolean(), z.literal("always")]).optional(),
+  symlinkNodeModules: z.boolean().optional(),
+
+  // Numbers
+  dryRunTimeoutMinutes: z.number().int().positive().optional(),
+  timeoutMS: z.number().int().positive().optional(),
+  timeoutFactor: z.number().positive().optional(),
+
+  // Incremental extras
+  incrementalFile: z.string().optional().describe("Path to stryker-incremental.json"),
+
+  // Dashboard (nested)
+  dashboard: z.object({
+    project: z.string().optional(),
+    version: z.string().optional(),
+    module: z.string().optional(),
+    baseUrl: z.string().optional(),
+    reportType: z.string().optional(),
+  }).optional(),
+
+  // Config hand-off
+  configFile: z.string().optional().describe("Path to an existing Stryker config file (passed as the last arg)"),
+  configOverrides: z.record(z.any()).optional().describe("Partial Stryker config to write to a temp JSON file and use as the config for this run"),
+
+  // Tool process timeout (not Stryker's internal timeouts)
+  execTimeoutSeconds: z.number().int().positive().optional().describe("Default 300s"),
+};
+
+export const ZStrykerRunInput = z.object(ZStrykerRunInputShape);
+export type StrykerRunInput = z.infer<typeof ZStrykerRunInput>;

--- a/packages/mcp-server/src/tools/strykerRunWithArgs.ts
+++ b/packages/mcp-server/src/tools/strykerRunWithArgs.ts
@@ -1,0 +1,90 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { access } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import {
+  ZStrykerRunInput,
+  ZStrykerRunInputShape,
+  type StrykerRunInput
+} from "../schemas/strykerRunInput.js";
+import { buildStrykerArgs } from "../utils/buildStrykerArgs.js";
+
+const execFileAsync = promisify(execFile);
+
+// Tiny helpers
+const exists = async (p: string) => { try { await access(p); return true; } catch { return false; } };
+
+/** Find npm’s JS CLI next to the current Node install (works cross-platform, avoids *.cmd) */
+async function findNpmCliJs(): Promise<string | undefined> {
+  const nodeDir = dirname(process.execPath);
+  const candidates = [
+    // Windows Node installer layout
+    join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js"),
+    // Unix/Homebrew layouts
+    join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+    join(nodeDir, "..", "node_modules", "npm", "bin", "npm-cli.js"),
+  ];
+  for (const c of candidates) if (await exists(c)) return c;
+  return undefined;
+}
+
+export function registerStrykerRunWithArgs(server: McpServer) {
+  server.registerTool(
+    "strykerRunWithArgs",
+    {
+      title: "Stryker Run (npm exec via npm-cli.js, no shell)",
+      description:
+        "Runs Stryker using npm exec semantics by invoking npm’s JS entrypoint with Node. Supports all documented options; ensures a JSON report is generated.",
+      inputSchema: ZStrykerRunInputShape,
+    },
+    async (rawInput) => {
+      const input: StrykerRunInput = ZStrykerRunInput.parse(rawInput);
+      const timeoutMs = (input.execTimeoutSeconds ?? 300) * 1000;
+
+      try {
+        const npmCli = await findNpmCliJs();
+        if (!npmCli) {
+          return {
+            content: [{
+              type: "text",
+              text: "Error: npm CLI (npm-cli.js) not found near this Node installation. Ensure Node was installed with npm."
+            }],
+            isError: true
+          };
+        }
+
+        const { args } = await buildStrykerArgs(input);
+        // If we have args, we need a boundary to separate npm exec args from stryker args
+        const boundary = args.length ? ["--"] as const : [];
+        // npm exec prefers local bin, auto-installs if missing
+        const argv = [npmCli, "exec", "-y", "stryker", "run", ...boundary, ...args];
+
+        await execFileAsync(process.execPath, argv, {
+          cwd: input.cwd,
+          timeout: timeoutMs,
+          shell: false,
+          windowsHide: true,
+        });
+
+        const reportPath = join(input.cwd, "reports", "mutation", "mutation.json");
+        return {
+          content: [{ type: "text", text: JSON.stringify({ reportPath, via: "npm exec (npm-cli.js)", argv }, null, 2) }],
+          isError: false,
+        };
+      } catch (err: any) {
+        if (err?.killed) {
+          return { content: [{ type: "text", text: "Error: Stryker run timed out" }], isError: true };
+        }
+        let errorMsg = err?.stderr || err?.stdout || err?.message || String(err);
+        if (errorMsg.includes("stryker: not found") || errorMsg.includes("Unknown command")) {
+          errorMsg =
+            "Stryker CLI not found. Add it as a devDependency (`npm i -D @stryker-mutator/core`) " +
+            "or allow temporary install via `npm exec -y` (already enabled).";
+        }
+        if (errorMsg.length > 1200) errorMsg = errorMsg.slice(-1200);
+        return { content: [{ type: "text", text: `Error: ${errorMsg.trim()}` }], isError: true };
+      }
+    }
+  );
+}

--- a/packages/mcp-server/src/utils/buildStrykerArgs.ts
+++ b/packages/mcp-server/src/utils/buildStrykerArgs.ts
@@ -1,0 +1,129 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { StrykerRunInput } from "../schemas/strykerRunInput.js";
+
+/**
+ * Build argv for Stryker from the the MCP client's input.
+ * - Adds json reporter by default (so mutation.json is produced)
+ * - Writes configOverrides to a temp file if provided and uses it as last arg
+ */
+export async function buildStrykerArgs(input: StrykerRunInput): Promise<{ args: string[]; configPath?: string }> {
+  const {
+    cwd,
+    mutate,
+    files,
+    ignorePatterns,
+    reporters,
+    logLevel,
+    fileLogLevel,
+    concurrency,
+    buildCommand,
+    coverageAnalysis,
+    testRunner,
+    testRunnerNodeArgs,
+    checkers,
+    checkerNodeArgs,
+    packageManager,
+    tsconfigFile,
+    tempDirName,
+    maxTestRunnerReuse,
+
+    allowConsoleColors,
+    allowEmpty,
+    disableBail,
+    dryRunOnly,
+    force,
+    ignoreStatic,
+    incremental,
+    inPlace,
+    cleanTempDir,
+    symlinkNodeModules,
+
+    dryRunTimeoutMinutes,
+    timeoutMS,
+    timeoutFactor,
+
+    incrementalFile,
+
+    dashboard,
+
+    configFile,
+    configOverrides,
+  } = input;
+
+  const args: string[] = [];
+
+  // Merge mutate aliases → comma-separated string for CLI
+  const mutateGlobs = [...(mutate ?? []), ...(files ?? [])];
+  if (mutateGlobs.length) {
+    args.push("--mutate", mutateGlobs.join(","));
+  }
+
+  if (ignorePatterns?.length) args.push("--ignorePatterns", ignorePatterns.join(","));
+
+  // Reporters: ensure JSON so mutation.json is produced
+  if (reporters?.length) {
+    const ensured = reporters.includes("json") ? reporters : [...reporters, "json"];
+    args.push("--reporters", ensured.join(","));
+  } else {
+    args.push("--reporters", "json");
+  }
+
+  // Simple flags & values
+  if (typeof allowConsoleColors === "boolean") args.push("--allowConsoleColors", String(allowConsoleColors));
+  if (allowEmpty) args.push("--allowEmpty");
+  if (disableBail) args.push("--disableBail");
+  if (dryRunOnly) args.push("--dryRunOnly");
+  if (force) args.push("--force");
+  if (ignoreStatic) args.push("--ignoreStatic");
+  if (incremental) args.push("--incremental");
+  if (inPlace) args.push("--inPlace");
+  if (symlinkNodeModules) args.push("--symlinkNodeModules");
+
+  if (cleanTempDir !== undefined) args.push("--cleanTempDir", String(cleanTempDir));
+  if (typeof concurrency === "number") args.push("--concurrency", String(concurrency));
+  if (buildCommand) args.push("--buildCommand", buildCommand);
+  if (checkers?.length) args.push("--checkers", checkers.join(","));
+  if (checkerNodeArgs?.length) args.push("--checkerNodeArgs", checkerNodeArgs.join(" "));
+  if (coverageAnalysis) args.push("--coverageAnalysis", coverageAnalysis);
+  if (typeof dryRunTimeoutMinutes === "number") args.push("--dryRunTimeoutMinutes", String(dryRunTimeoutMinutes));
+  if (fileLogLevel) args.push("--fileLogLevel", fileLogLevel);
+  if (logLevel) args.push("--logLevel", logLevel);
+  if (typeof maxTestRunnerReuse === "number") args.push("--maxTestRunnerReuse", String(maxTestRunnerReuse));
+  if (packageManager) args.push("--packageManager", packageManager);
+  if (tempDirName) args.push("--tempDirName", tempDirName);
+  if (testRunner) args.push("--testRunner", testRunner);
+  if (testRunnerNodeArgs?.length) args.push("--testRunnerNodeArgs", testRunnerNodeArgs.join(" "));
+  if (typeof timeoutFactor === "number") args.push("--timeoutFactor", String(timeoutFactor));
+  if (typeof timeoutMS === "number") args.push("--timeoutMS", String(timeoutMS));
+  if (tsconfigFile) args.push("--tsconfigFile", tsconfigFile);
+  if (incrementalFile) args.push("--incrementalFile", incrementalFile);
+
+  // Dashboard nested flags
+  if (dashboard?.project) args.push("--dashboard.project", dashboard.project);
+  if (dashboard?.version) args.push("--dashboard.version", dashboard.version);
+  if (dashboard?.module) args.push("--dashboard.module", dashboard.module);
+  if (dashboard?.baseUrl) args.push("--dashboard.baseUrl", dashboard.baseUrl);
+  if (dashboard?.reportType) args.push("--dashboard.reportType", dashboard.reportType);
+
+  // Config precedence:
+  // 1) configOverrides -> write temp JSON and use it as last arg
+  // 2) else configFile -> pass it as last arg (resolved from cwd)
+  // 3) else rely on auto-detection
+  let finalConfigPath: string | undefined;
+  if (configOverrides) {
+    const dir = await mkdtemp(join(tmpdir(), "stryker-mcp-"));
+    finalConfigPath = join(dir, "stryker.overrides.json");
+    await writeFile(finalConfigPath, JSON.stringify(configOverrides, null, 2), "utf8");
+  } else if (configFile) {
+    finalConfigPath = resolve(cwd, configFile);
+  }
+
+  if (finalConfigPath) {
+    // Stryker accepts the config file path as a positional argument at the end
+    args.push(finalConfigPath);
+  }
+
+  return { args, configPath: finalConfigPath };
+}


### PR DESCRIPTION
The new strykerRunWithArgs tool adds support for all stryker configuration options (documented at https://stryker-mutator.io/docs/stryker-js/configuration/)

Will eventually replace StrykerRun. For now, only jest test runner has been tested

TODO:

1) Verify if all arguments work
2) Verify if args are properly escaped