### PR TITLE
Vscode integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 node_modules
-.vscode
-.idea
+.vscode/*
+!.vscode/settings.json
+!.vscode/mcp.json
 reports/*
 /reports
 build/
-idea
+.idea

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,15 @@
+{
+	"servers": {
+		"stryker-mcp-server": {
+			"type": "stdio",
+			"command": "npm",
+			"args": [
+				"run",
+				"--workspace",
+				"mcp-server",
+				"mcp"
+			]
+		}
+	},
+	"inputs": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cSpell.words": [
+        "modelcontextprotocol"
+    ],
+    "jest.jestCommandLine": "npm run test --",
+    "jest.rootPath": "packages\\example-app"
+}

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -5,9 +5,11 @@
   "private": true,
   "description": "PoC implementation of a Stryker MCP server",
   "scripts": {
+    
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node --enable-source-maps build/index.js",
+    "mcp": "npm run build && node --enable-source-maps build/index.js",
     "inspect": "npm run build && npx @modelcontextprotocol/inspector@latest node --enable-source-maps build/index.js"
   },
   "dependencies": {

--- a/packages/mcp-server/src/tools/strykerMutationTest.ts
+++ b/packages/mcp-server/src/tools/strykerMutationTest.ts
@@ -117,18 +117,10 @@ async function strykerMutationTestHandler(
     // await writeFile(reportPath, JSON.stringify(result, null, 2), "utf-8");
 
     return {
-      content: [
-        {
-          type: "resource",
-          resource: {
-            uri: `file://${reportPath}`,
-            text: JSON.stringify(result, null, 2),
-            mimeType: "application/json",
-          },
-        },
-      ],
-      structuredContent: result,
+      content: [],
+      structuredContent: result
     };
+
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return {


### PR DESCRIPTION
Add an build&run script 'mcp' to package.json that we can call from .vscode/mcp.json to expose the MCP server to Copilot.
Fix a bug in strykerMutationTest that prevented successful startup