### PR TITLE
Add iterative test generation prompt

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,4 +1,4 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpServer, RegisteredPrompt } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {createStrykerServer} from "./stryker/createStrykerServer.ts";
 import { registerStrykerDiscover } from "./tools/strykerDiscover.ts";
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { registerStrykerConfigure } from "./tools/strykerConfigure.ts";
 import { registerStrykerMutationTest } from "./tools/strykerMutationTest.ts";
+import { registerTestGenerationPrompt } from "./prompts/testGenerationPrompt.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,5 +29,6 @@ registerStrykerStart(mcpServer, strykerServer);
 registerStrykerConfigure(mcpServer, strykerServer);
 registerStrykerDiscover(mcpServer, strykerServer);
 registerStrykerMutationTest(mcpServer, strykerServer);
+registerTestGenerationPrompt(mcpServer);
 
 await mcpServer.connect(new StdioServerTransport());

--- a/packages/mcp-server/src/prompts/testGenerationPrompt.ts
+++ b/packages/mcp-server/src/prompts/testGenerationPrompt.ts
@@ -1,0 +1,89 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { PromptMessage } from "@modelcontextprotocol/sdk/types.js";
+
+
+// Zod schema for the prompt arguments
+const iterativeTestArgsSchema = z.object({
+  projectDirectory: z.string().describe("Path to the project root"),
+  maxIterations: z.coerce // Use coerce to automatically convert strings to numbers. Necessary because inspector UI turns everything into strings
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(4)
+    .describe("Maximum number of mutation test iterations"),
+});
+
+export function registerTestGenerationPrompt(
+  mcpServer: McpServer
+) {
+  mcpServer.registerPrompt(
+    "strykerPrompt", 
+    {title: "Iterative Unit Test Generation for JavaScript/TypeScript Projects with Stryker",
+    description:
+      "Generate and improve tests with Stryker. Start the mutation server, create tests, " +
+      "run mutation analysis, and iteratively improve until convergence or a maximum number of iterations.",
+    argsSchema: iterativeTestArgsSchema.shape
+    },
+    // The callback builds the messages that clients will retrieve
+    async ({ projectDirectory, maxIterations }) => {
+      const messages: PromptMessage[] = [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `You are an expert test generator tasked with creating and iteratively improving unit tests for a JavaScript/TypeScript project using Stryker mutation testing.
+
+**Project Directory**: ${projectDirectory}
+**Maximum Iterations**: ${maxIterations}
+
+**Your Workflow**:
+
+1. **Check Stryker Server Status**
+   - First, check if the Stryker mutation server is already running
+   - If NOT already started, use the \`strykerStart\` tool to initialize it with:
+     - cwd: ${projectDirectory}
+     - configFilePath: (path to stryker.config.mjs in the project directory)
+   - If already started, skip this step and proceed to discovery
+
+2. **Discover Mutants**
+   - Use the \`strykerDiscover\` tool to find all potential mutations in the source code
+   - Analyze the discovered mutants to understand what code needs test coverage
+
+3. **Generate/Improve Tests**
+   - Create or enhance test files to kill the surviving mutants
+   - Focus on edge cases, boundary conditions, and mutation-specific scenarios
+   - Ensure tests are specific and meaningful, not just increasing coverage
+
+4. **Run Mutation Testing**
+   - Use the \`strykerMutationTest\` tool with the discovered mutants
+   - Pass the mutants from the discover step to the mutation test
+   - Analyze the results to identify surviving mutants
+
+5. **Iterate**
+   - Review which mutants survived and why
+   - Improve tests to kill surviving mutants
+   - Repeat steps 2-4 up to ${maxIterations} times or until mutation score converges (improvement < 5%)
+
+6. **Final Report**
+   - Provide a summary of:
+     - Final mutation score
+     - Number of iterations performed
+     - Key improvements made
+     - Any remaining surviving mutants and why they might be acceptable
+
+**Important Notes**:
+- Do NOT restart the Stryker server if it's already running
+- Each iteration should show measurable improvement in mutation score
+- Stop early if mutation score stops improving significantly
+- Focus on quality tests that catch real bugs, not just satisfying mutation coverage`,
+          },
+        },
+      ];
+      return { messages };
+    }
+  )
+}
+
+

--- a/packages/mcp-server/src/prompts/testGenerationPrompt.ts
+++ b/packages/mcp-server/src/prompts/testGenerationPrompt.ts
@@ -52,7 +52,7 @@ export function registerTestGenerationPrompt(
    - Analyze the discovered mutants to understand what code needs test coverage
 
 3. **Generate/Improve Tests**
-   - Create or enhance test files to kill the surviving mutants
+   - Create or enhance (Jest) test files to kill the surviving mutants
    - Focus on edge cases, boundary conditions, and mutation-specific scenarios
    - Ensure tests are specific and meaningful, not just increasing coverage
 


### PR DESCRIPTION
Register a prompt to the MCP server. This can be accessed by MCP clients that support prompts. For example, I can access it through VS Code Copilot with /stryker-mcp-server.strykerPrompt. VS Code will then prompt me for details (project dir and number of iterations) before prompting the Copilot model with the extensive test generation prompt. One test run seemed to catch all the weaknesses in the existing test corpus of example-app.