### PR TITLE
Update logging and passing of CLI arguments

### DIFF
--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,4 +1,3 @@
-import ora from 'ora';
 import { MCPAgent } from 'mcp-use';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -8,8 +7,10 @@ import { resolveLLMConfig } from '../llm/resolveLLMConfig.ts';
 import { createLLM } from '../llm/providers.ts';
 import { createMCPClient } from '../mcp/createClient.ts';
 import { loadStrykerPrompt } from '../mcp/loadStrykerPrompt.ts';
-import { createLogger } from '../utils/logger.ts';
 import { createMCPConfig } from '../mcp/config.ts';
+import { createCliContext } from '../context.ts';
+import { MetricsCollector } from '../metrics/MetricsCollector.ts';
+import { formatTraceText } from '../metrics/formatTrace.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -25,12 +26,8 @@ export interface GenerateOptions {
 }
 
 export async function generateTests(options: GenerateOptions) {
-	const logger = createLogger({
-		json: !!options.json,
-		verbose: !!options.verbose,
-	});
-
-	const spinner = options.json ? null : ora();
+	const ctx = createCliContext(options);
+	const { logger, spinner } = ctx;
 
 	let agent: MCPAgent | undefined;
 	let client: ReturnType<typeof createMCPClient> | undefined;
@@ -56,9 +53,7 @@ export async function generateTests(options: GenerateOptions) {
 		const monorepoRoot = join(__dirname, '..', '..', '..', '..');
 		const mcpConfig = createMCPConfig(projectDirectory, monorepoRoot);
 
-		client = createMCPClient(mcpConfig, {
-			verbose: options.verbose,
-		});
+		client = createMCPClient(mcpConfig, ctx);
 
 		spinner?.start('Connecting MCP servers...');
 		await client.createAllSessions();
@@ -81,17 +76,34 @@ export async function generateTests(options: GenerateOptions) {
 			llm,
 			client,
 			maxSteps: 1000,
-			verbose: options.verbose,
+			verbose: ctx.verbose,
 			memoryEnabled: true,
 		});
 		await agent.initialize();
 		logger.info('Agent started');
 
-		for await (const _ of agent.prettyStreamEvents({
+		const metrics = new MetricsCollector();
+		const eventStream = agent.streamEvents({
 			prompt,
 			maxSteps: 1000,
-		})) {
-			// Just drain the stream
+		});
+
+		for await (const event of metrics.wrap(eventStream)) {
+			// Render streamed LLM text to stdout (mimics prettyStreamEvents)
+			if (event.event === 'on_chat_model_stream' && event.data?.chunk) {
+				const text = event.data.chunk.text ?? event.data.chunk.content;
+				if (typeof text === 'string' && text.length > 0) {
+					process.stdout.write(text);
+				}
+			}
+		}
+
+		const trace = metrics.finalise();
+
+		if (ctx.json) {
+			logger.info('Session trace', trace);
+		} else {
+			console.log(formatTraceText(trace));
 		}
 
 		logger.info('Test generation completed');

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -1,0 +1,27 @@
+import ora, { type Ora } from 'ora';
+import { createLogger, type Logger } from './utils/logger.ts';
+
+/**
+ * Cross-cutting concerns shared across all CLI sub-modules.
+ *
+ * Created once at command entry and threaded through helpers so that
+ * no module needs to re-derive verbose/json flags or build its own logger.
+ */
+export interface CliContext {
+	readonly logger: Logger;
+	readonly spinner: Ora | null;
+	readonly verbose: boolean;
+	readonly json: boolean;
+}
+
+export function createCliContext(options: { json?: boolean; verbose?: boolean }): CliContext {
+	const json = !!options.json;
+	const verbose = !!options.verbose;
+
+	return {
+		logger: createLogger({ json, verbose }),
+		spinner: json ? null : ora(),
+		verbose,
+		json,
+	};
+}

--- a/packages/cli/src/mcp/createClient.ts
+++ b/packages/cli/src/mcp/createClient.ts
@@ -1,21 +1,16 @@
-import { MCPClient, Logger } from 'mcp-use';
-import { MCPConfig } from './config.ts';
-import type { Notification } from 'mcp-use';
+import { MCPClient, Logger as McpUseLogger } from 'mcp-use';
+import type { MCPConfig } from './config.ts';
+import type { CliContext } from '../context.ts';
 
-export interface CreateMCPClientOptions {
-	verbose?: boolean;
-	onNotification?: (serverName: string, notification: Notification) => void;
-}
-
-export function createMCPClient(config: MCPConfig, options?: CreateMCPClientOptions): MCPClient {
-	// Configure mcp-use logging based on verbose flag
-	if (options?.verbose) {
-		Logger.configure({ level: 'debug' });
+export function createMCPClient(config: MCPConfig, ctx: CliContext): MCPClient {
+	// Bridge our verbose flag to mcp-use's global logger
+	if (ctx.verbose) {
+		McpUseLogger.configure({ level: 'debug' });
 	}
 
-	const client = new MCPClient({
+	ctx.logger.debug('Creating MCP client', config);
+
+	return new MCPClient({
 		mcpServers: config,
 	});
-
-	return client;
 }

--- a/packages/cli/src/metrics/MetricsCollector.ts
+++ b/packages/cli/src/metrics/MetricsCollector.ts
@@ -1,0 +1,316 @@
+/**
+ * MetricsCollector — wraps an `agent.streamEvents()` async generator and
+ * transparently collects timing, token-usage and tool-call metrics from
+ * the LangChain StreamEvent objects that flow through.
+ *
+ * Usage:
+ *   const collector = new MetricsCollector();
+ *   for await (const event of collector.wrap(agent.streamEvents({ prompt }))) {
+ *     // render as before – events pass through unchanged
+ *   }
+ *   const trace = collector.finalise();   // structured SessionTrace
+ */
+
+import type { StreamEvent } from '@langchain/core/tracers/log_stream';
+import type {
+	LLMCallMetrics,
+	LLMCallTokens,
+	SessionSummary,
+	SessionTrace,
+	ToolCallMetrics,
+} from './types.ts';
+
+// ── Internal bookkeeping for in-flight calls ──────────────────────────────
+
+interface InflightLLMCall {
+	callIndex: number;
+	model?: string;
+	startMs: number;
+	firstTokenMs: number | null;
+	tokens: LLMCallTokens;
+}
+
+interface InflightToolCall {
+	callIndex: number;
+	toolName: string;
+	/** Stringified input for retry-detection heuristic. */
+	inputKey: string;
+	startMs: number;
+}
+
+export class MetricsCollector {
+	// ── Completed metrics ────────────────────────────────────────────
+	private readonly llmCalls: LLMCallMetrics[] = [];
+	private readonly toolCalls: ToolCallMetrics[] = [];
+
+	// ── In-flight tracking (keyed by run_id) ─────────────────────────
+	private readonly inflightLLM = new Map<string, InflightLLMCall>();
+	private readonly inflightTools = new Map<string, InflightToolCall>();
+
+	// ── Counters ────────────────────────────────────────────────────
+	private llmCallCounter = 0;
+	private toolCallCounter = 0;
+
+	// ── Retry detection ─────────────────────────────────────────────
+	private lastToolKey: string | null = null;
+	private retries = 0;
+
+	// Track failure reasons per tool
+	private readonly toolFailureReasons = new Map<string, Map<string, number>>();
+
+	// ── Session boundary ────────────────────────────────────────────
+	private sessionStartMs = 0;
+	private sessionEndMs = 0;
+	private started = false;
+
+	/**
+	 * Wrap an existing `streamEvents()` generator.
+	 * Every yielded event is inspected, then forwarded unchanged.
+	 */
+	async *wrap(
+		source: AsyncGenerator<StreamEvent, void, void>,
+	): AsyncGenerator<StreamEvent, void, void> {
+		this.sessionStartMs = Date.now();
+		this.started = true;
+
+		try {
+			for await (const event of source) {
+				this.process(event);
+				yield event;
+			}
+		} finally {
+			this.sessionEndMs = Date.now();
+		}
+	}
+
+	// ── Event dispatcher ────────────────────────────────────────────
+
+	private process(event: StreamEvent): void {
+		switch (event.event) {
+			case 'on_chat_model_start':
+				this.onLLMStart(event);
+				break;
+			case 'on_chat_model_stream':
+				this.onLLMStream(event);
+				break;
+			case 'on_chat_model_end':
+				this.onLLMEnd(event);
+				break;
+			case 'on_tool_start':
+				this.onToolStart(event);
+				break;
+			case 'on_tool_end':
+				this.onToolEnd(event, true);
+				break;
+			case 'on_tool_error':
+				this.onToolEnd(event, false);
+				break;
+		}
+	}
+
+	// ── LLM lifecycle ────────────────────────────────────────────────
+
+	private onLLMStart(event: StreamEvent): void {
+		const runId = event.run_id ?? `llm-${this.llmCallCounter}`;
+		this.inflightLLM.set(runId, {
+			callIndex: this.llmCallCounter++,
+			model: event.name ?? undefined,
+			startMs: Date.now(),
+			firstTokenMs: null,
+			tokens: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+		});
+	}
+
+	private onLLMStream(event: StreamEvent): void {
+		const runId = event.run_id;
+		if (!runId) return;
+		const inflight = this.inflightLLM.get(runId);
+		if (inflight && inflight.firstTokenMs === null) {
+			inflight.firstTokenMs = Date.now();
+		}
+	}
+
+	private onLLMEnd(event: StreamEvent): void {
+		const runId = event.run_id;
+		if (!runId) return;
+		const inflight = this.inflightLLM.get(runId);
+		if (!inflight) return;
+
+		const endMs = Date.now();
+
+		// Try to extract token usage from the AIMessage output.
+		// LangChain providers attach usage_metadata on the AIMessage.
+		const output = event.data?.output;
+		const usage =
+			output?.usage_metadata ??
+			output?.response_metadata?.usage ??
+			output?.response_metadata?.tokenUsage ??
+			undefined;
+
+		if (usage) {
+			inflight.tokens = {
+				promptTokens: usage.input_tokens ?? usage.prompt_tokens ?? usage.promptTokens ?? 0,
+				completionTokens:
+					usage.output_tokens ?? usage.completion_tokens ?? usage.completionTokens ?? 0,
+				totalTokens:
+					usage.total_tokens ??
+					usage.totalTokens ??
+					(usage.input_tokens ?? 0) + (usage.output_tokens ?? 0),
+			};
+		}
+
+		this.llmCalls.push({
+			callIndex: inflight.callIndex,
+			model: inflight.model,
+			latencyMs: endMs - inflight.startMs,
+			ttftMs:
+				inflight.firstTokenMs !== null ? inflight.firstTokenMs - inflight.startMs : null,
+			tokens: inflight.tokens,
+		});
+
+		this.inflightLLM.delete(runId);
+	}
+
+	// ── Tool lifecycle ──────────────────────────────────────────────
+
+	private onToolStart(event: StreamEvent): void {
+		const runId = event.run_id ?? `tool-${this.toolCallCounter}`;
+		const toolName = event.name ?? 'unknown';
+		const inputKey = `${toolName}::${JSON.stringify(event.data?.input ?? {})}`;
+
+		// Retry heuristic: same tool + same input back-to-back.
+		if (this.lastToolKey !== null && inputKey === this.lastToolKey) {
+			this.retries++;
+		}
+		this.lastToolKey = inputKey;
+
+		this.inflightTools.set(runId, {
+			callIndex: this.toolCallCounter++,
+			toolName,
+			inputKey,
+			startMs: Date.now(),
+		});
+	}
+
+	private onToolEnd(event: StreamEvent, success: boolean): void {
+		const runId = event.run_id;
+		if (!runId) return;
+		const inflight = this.inflightTools.get(runId);
+		if (!inflight) return;
+
+		const endMs = Date.now();
+		const metrics: ToolCallMetrics = {
+			callIndex: inflight.callIndex,
+			toolName: inflight.toolName,
+			latencyMs: endMs - inflight.startMs,
+			success,
+		};
+
+		if (!success) {
+			const errorData = event.data as Record<string, unknown> | undefined;
+			const errorField = errorData?.error;
+			metrics.error =
+				typeof errorField === 'string'
+					? errorField
+					: ((errorField as { message?: string } | undefined)?.message ??
+						'Unknown error');
+
+			// Increment failure reason counts
+			const reason = metrics.error;
+			let byReason = this.toolFailureReasons.get(inflight.toolName);
+			if (!byReason) {
+				byReason = new Map();
+				this.toolFailureReasons.set(inflight.toolName, byReason);
+			}
+			byReason.set(reason, (byReason.get(reason) ?? 0) + 1);
+		}
+
+		this.toolCalls.push(metrics);
+		this.inflightTools.delete(runId);
+	}
+
+	public getToolFailureStats(): Record<string, Record<string, number>> {
+		const out: Record<string, Record<string, number>> = {};
+		for (const [tool, map] of this.toolFailureReasons) {
+			out[tool] = {};
+			for (const [reason, count] of map) out[tool][reason] = count;
+		}
+		return out;
+	}
+
+	// ── Produce the final structured trace ───────────────────────────
+
+	/**
+	 * Call after the wrapped generator has been fully consumed.
+	 * Returns the complete, immutable session trace.
+	 */
+	finalise(): SessionTrace {
+		const endMs = this.sessionEndMs || Date.now();
+		const totalDurationMs = endMs - this.sessionStartMs;
+
+		// Token aggregates
+		let totalPromptTokens = 0;
+		let totalCompletionTokens = 0;
+		let totalTokens = 0;
+		const promptTokenGrowth: number[] = [];
+
+		for (const call of this.llmCalls) {
+			totalPromptTokens += call.tokens.promptTokens;
+			totalCompletionTokens += call.tokens.completionTokens;
+			totalTokens += call.tokens.totalTokens;
+			promptTokenGrowth.push(call.tokens.promptTokens);
+		}
+
+		// LLM latency
+		const llmLatencies = this.llmCalls.map((c) => c.latencyMs);
+		const avgLLMLatencyMs =
+			llmLatencies.length > 0
+				? llmLatencies.reduce((a, b) => a + b, 0) / llmLatencies.length
+				: 0;
+
+		// TTFT
+		const ttfts = this.llmCalls.map((c) => c.ttftMs).filter((t): t is number => t !== null);
+		const avgTTFTMs = ttfts.length > 0 ? ttfts.reduce((a, b) => a + b, 0) / ttfts.length : null;
+
+		// Tool aggregates
+		const toolSuccessCount = this.toolCalls.filter((t) => t.success).length;
+		const toolFailureCount = this.toolCalls.filter((t) => !t.success).length;
+		const toolLatencies = this.toolCalls.map((t) => t.latencyMs);
+		const avgToolLatencyMs =
+			toolLatencies.length > 0
+				? toolLatencies.reduce((a, b) => a + b, 0) / toolLatencies.length
+				: 0;
+
+		const summary: SessionSummary = {
+			totalDurationMs,
+			totalPromptTokens,
+			totalCompletionTokens,
+			totalTokens,
+			promptTokenGrowth,
+			llmCallCount: this.llmCalls.length,
+			avgLLMLatencyMs: Math.round(avgLLMLatencyMs),
+			avgTTFTMs: avgTTFTMs !== null ? Math.round(avgTTFTMs) : null,
+			toolCallCount: this.toolCalls.length,
+			toolSuccessCount,
+			toolFailureCount,
+			toolSuccessRate:
+				this.toolCalls.length > 0 ? toolSuccessCount / this.toolCalls.length : 1,
+			avgToolLatencyMs: Math.round(avgToolLatencyMs),
+			estimatedRetries: this.retries,
+		};
+
+		return {
+			startedAt: new Date(this.sessionStartMs).toISOString(),
+			endedAt: new Date(endMs).toISOString(),
+			llmCalls: [...this.llmCalls],
+			toolCalls: [...this.toolCalls],
+			toolFailureStats: this.getToolFailureStats(),
+			summary,
+		};
+	}
+
+	/** Whether `wrap()` has been called. */
+	get isStarted(): boolean {
+		return this.started;
+	}
+}

--- a/packages/cli/src/metrics/formatTrace.ts
+++ b/packages/cli/src/metrics/formatTrace.ts
@@ -1,0 +1,98 @@
+import chalk from 'chalk';
+import type { SessionTrace } from './types.ts';
+
+/**
+ * Format a SessionTrace as a human-readable summary for terminal output.
+ */
+export function formatTraceText(trace: SessionTrace): string {
+	const { summary: s } = trace;
+	const lines: string[] = [];
+
+	lines.push('');
+	lines.push(chalk.bold.cyan('──── Session Metrics ────────────────────────────────────'));
+	lines.push('');
+
+	// ── Timing ───────────────────────────────────────────
+	lines.push(chalk.bold('Timing'));
+	lines.push(`  Total duration        ${fmtMs(s.totalDurationMs)}`);
+	lines.push(`  Avg LLM latency       ${fmtMs(s.avgLLMLatencyMs)}`);
+	lines.push(
+		`  Avg TTFT              ${s.avgTTFTMs !== null ? fmtMs(s.avgTTFTMs) : chalk.dim('n/a')}`,
+	);
+	lines.push(`  Avg tool latency      ${fmtMs(s.avgToolLatencyMs)}`);
+	lines.push('');
+
+	// ── Tokens ───────────────────────────────────────────
+	lines.push(chalk.bold('Tokens'));
+	lines.push(`  Prompt tokens         ${s.totalPromptTokens.toLocaleString()}`);
+	lines.push(`  Completion tokens     ${s.totalCompletionTokens.toLocaleString()}`);
+	lines.push(`  Total tokens          ${s.totalTokens.toLocaleString()}`);
+
+	if (s.promptTokenGrowth.length > 1) {
+		const growth = s.promptTokenGrowth.map((t) => t.toLocaleString()).join(' → ');
+		lines.push(`  Prompt growth/step    ${growth}`);
+	}
+	lines.push('');
+
+	// ── LLM Calls ────────────────────────────────────────
+	lines.push(chalk.bold('LLM Calls'));
+	lines.push(`  Count                 ${s.llmCallCount}`);
+
+	if (trace.llmCalls.length > 0) {
+		for (const call of trace.llmCalls) {
+			const ttft = call.ttftMs !== null ? `TTFT ${fmtMs(call.ttftMs)}` : chalk.dim('no TTFT');
+			lines.push(
+				`    #${call.callIndex}  ${fmtMs(call.latencyMs)}  ${ttft}  ` +
+					`in:${call.tokens.promptTokens} out:${call.tokens.completionTokens}`,
+			);
+		}
+	}
+	lines.push('');
+
+	// ── Tool Calls ───────────────────────────────────────
+	lines.push(chalk.bold('Tool Calls'));
+	lines.push(`  Count                 ${s.toolCallCount}`);
+	lines.push(
+		s.toolCallCount > 0
+			? `  Success rate          ${(s.toolSuccessRate * 100).toFixed(0)}%  ` +
+					`(${s.toolSuccessCount} ok / ${s.toolFailureCount} failed)`
+			: `  Success rate          ${chalk.dim('n/a')}  ` +
+					`(${s.toolSuccessCount} ok / ${s.toolFailureCount} failed)`,
+	);
+	lines.push(`  Estimated retries     ${s.estimatedRetries}`);
+
+	if (trace.toolCalls.length > 0) {
+		for (const call of trace.toolCalls) {
+			const status = call.success ? chalk.green('✓') : chalk.red('✗');
+			const err = call.error ? `  ${chalk.red(call.error)}` : '';
+			lines.push(
+				`    #${call.callIndex}  ${status} ${call.toolName}  ${fmtMs(call.latencyMs)}${err}`,
+			);
+		}
+	}
+
+	const toolFailureTools = Object.keys(trace.toolFailureStats);
+	if (toolFailureTools.length > 0) {
+		lines.push('');
+		lines.push(chalk.bold('Tool Failure Reasons'));
+		for (const tool of toolFailureTools) {
+			lines.push(`  ${tool}`);
+			const byReason = trace.toolFailureStats[tool] ?? {};
+			for (const [reason, count] of Object.entries(byReason)) {
+				lines.push(`    ${count}x  ${chalk.red(reason)}`);
+			}
+		}
+	}
+
+	lines.push('');
+	lines.push(chalk.bold.cyan('─────────────────────────────────────────────────────────'));
+	lines.push('');
+
+	return lines.join('\n');
+}
+
+/** Milliseconds → human string ("1234 ms" or "2.3 s"). */
+function fmtMs(ms: number): string {
+	if (ms < 1000) return `${ms} ms`;
+	return `${(ms / 1000).toFixed(1)} s`;
+}

--- a/packages/cli/src/metrics/index.ts
+++ b/packages/cli/src/metrics/index.ts
@@ -1,0 +1,9 @@
+export { MetricsCollector } from './MetricsCollector.ts';
+export { formatTraceText } from './formatTrace.ts';
+export type {
+	LLMCallMetrics,
+	LLMCallTokens,
+	SessionSummary,
+	SessionTrace,
+	ToolCallMetrics,
+} from './types.ts';

--- a/packages/cli/src/metrics/types.ts
+++ b/packages/cli/src/metrics/types.ts
@@ -1,0 +1,98 @@
+/**
+ * Types for structured session trace and metrics collection.
+ *
+ * All durations are in milliseconds.
+ */
+
+/** Token counts for a single LLM call. */
+export interface LLMCallTokens {
+	promptTokens: number;
+	completionTokens: number;
+	totalTokens: number;
+}
+
+/** Metrics for a single LLM invocation within the session. */
+export interface LLMCallMetrics {
+	/** Sequential call index (0-based). */
+	callIndex: number;
+	/** Model name reported by the event, if available. */
+	model?: string;
+	/** Wall-clock latency of the full LLM call (start → end). */
+	latencyMs: number;
+	/** Time to first streamed token (start → first on_chat_model_stream). */
+	ttftMs: number | null;
+	/** Token usage as reported by the provider. */
+	tokens: LLMCallTokens;
+}
+
+/** Metrics for a single MCP tool invocation. */
+export interface ToolCallMetrics {
+	/** Sequential call index across the whole session (0-based). */
+	callIndex: number;
+	/** The tool name from the event. */
+	toolName: string;
+	/** Wall-clock latency. */
+	latencyMs: number;
+	/** Whether the call succeeded. */
+	success: boolean;
+	/** Error message when `success === false`. */
+	error?: string;
+}
+
+/** Aggregated summary for the entire session / task. */
+export interface SessionSummary {
+	/** Total wall-clock time for the task. */
+	totalDurationMs: number;
+
+	// ── Token metrics ────────────────────────────────────────────────
+	totalPromptTokens: number;
+	totalCompletionTokens: number;
+	totalTokens: number;
+
+	/** Per-LLM-call input-token counts – useful for detecting prompt bloat. */
+	promptTokenGrowth: number[];
+
+	// ── LLM call metrics ─────────────────────────────────────────────
+	llmCallCount: number;
+	/** Average LLM call latency. */
+	avgLLMLatencyMs: number;
+	/** Average time-to-first-token (only over calls where TTFT was measured). */
+	avgTTFTMs: number | null;
+
+	// ── Tool call metrics ────────────────────────────────────────────
+	toolCallCount: number;
+	toolSuccessCount: number;
+	toolFailureCount: number;
+	toolSuccessRate: number;
+	/** Average tool call latency. */
+	avgToolLatencyMs: number;
+
+	// ── Retry detection ──────────────────────────────────────────────
+	/**
+	 * Number of back-to-back duplicate tool calls (same tool name + input).
+	 * This is a heuristic for retry behaviour.
+	 */
+	estimatedRetries: number;
+}
+/** The full structured trace for one agent session / task. */
+export interface SessionTrace {
+	startedAt: string;
+	endedAt: string;
+	llmCalls: LLMCallMetrics[];
+	toolCalls: ToolCallMetrics[];
+	toolFailureStats: Record<string, Record<string, number>>;
+	summary: SessionSummary;
+}
+
+export interface SessionTrace {
+	/** ISO-8601 timestamp when the session started. */
+	startedAt: string;
+	/** ISO-8601 timestamp when the session ended. */
+	endedAt: string;
+	/** Ordered list of every LLM call in the session. */
+	llmCalls: LLMCallMetrics[];
+	/** Ordered list of every tool call in the session. */
+	toolCalls: ToolCallMetrics[];
+	/** Aggregated summary. */
+	summary: SessionSummary;
+}

--- a/packages/cli/src/utils/logger.ts
+++ b/packages/cli/src/utils/logger.ts
@@ -1,11 +1,18 @@
 import chalk from 'chalk';
 
+/** Structured logger that all CLI modules can depend on. */
+export interface Logger {
+	info(message: string, data?: unknown): void;
+	error(message: string, data?: unknown): void;
+	debug(message: string, data?: unknown): void;
+}
+
 export interface LoggerOptions {
 	json: boolean;
 	verbose: boolean;
 }
 
-export function createLogger(opts: LoggerOptions) {
+export function createLogger(opts: LoggerOptions): Logger {
 	function log(level: 'info' | 'error' | 'debug', message: string, data?: unknown) {
 		if (level === 'debug' && !opts.verbose) return;
 


### PR DESCRIPTION
Cli now keeps track of token usage and tool call failures and successes.
Improved structure slightly by introducing CliContext which can be used to pass around the verbose flag